### PR TITLE
Setting upper version bound for urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ websocket-client>=0.32.0,!=0.40.0,!=0.41.*,!=0.42.* # LGPLv2+
 requests # Apache-2.0
 requests-oauthlib # ISC
 oauthlib>=3.2.2 # BSD
-urllib3>=1.24.2  # MIT
+urllib3>=1.24.2,<2.0  # MIT


### PR DESCRIPTION
Since google-auth doesn't support urllib3>2.0 (https://github.com/googleapis/google-auth-library-python/issues/1365), an upper version bound for urllib3 needs to be set. Otherwise the package is not installable, since the dependency to google-auth breaks.

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
It fixed breaking dependencies.

#### Does this PR introduce a user-facing change?
NONE

```
release-note

fix upper version boundary of urllib3, since other dependencies don't support urllib3 in version 2
```

